### PR TITLE
Refactor Hammerspoon modules

### DIFF
--- a/hammerspoon/hammerbrowser.lua
+++ b/hammerspoon/hammerbrowser.lua
@@ -1,7 +1,7 @@
 -- https://zzamboni.org/post/my-hammerspoon-configuration-with-commentary/
 
-function appID(app)
-	return hs.application.infoForBundlePath(app)['CFBundleIdentifier']
+local function appID(app)
+        return hs.application.infoForBundlePath(app)['CFBundleIdentifier']
 end
 
 safariBrowser = appID('/Applications/Safari.app')

--- a/hammerspoon/init.lua
+++ b/hammerspoon/init.lua
@@ -11,8 +11,8 @@ mehkey = { "ctrl", "alt", "shift" }
 reimod = mehkey
 
 -- require('ergomouse')
-require('showkeymap')
-hs.hotkey.bind(reimod, "=", toggleKeymap)
+local showkeymap = require('showkeymap')
+hs.hotkey.bind(reimod, "=", showkeymap.toggleKeymap)
 
 menuHammer = hs.loadSpoon("MenuHammer")
 menuHammer:enter()

--- a/hammerspoon/secrets.lua
+++ b/hammerspoon/secrets.lua
@@ -2,9 +2,9 @@
 -- Inspiration: https://github.com/evantravers/hammerspoon-config/blob/master/secrets.lua
 -- Really stupid simple loading of secrets into `hs.settings`.
 
-module = {}
+local M = {}
 
-module.start = function(filename)
+function M.start(filename)
 	if hs.fs.attributes(filename) then
 		hs.settings.set("secrets", hs.json.read(filename))
 	else
@@ -12,4 +12,4 @@ module.start = function(filename)
 	end
 end
 
-return module
+return M

--- a/hammerspoon/showkeymap.lua
+++ b/hammerspoon/showkeymap.lua
@@ -1,4 +1,9 @@
-showKeymap = function()
+local M = {}
+
+local modalCanvas
+local mapShown = 0
+
+function M.showKeymap()
 	local frame = hs.screen.mainScreen():frame()
 	local currentScreen = hs.screen.mainScreen():name()
 	-- if (currentScreen == 'LG UltraFine') then
@@ -22,11 +27,11 @@ showKeymap = function()
 	modalCanvas:show(0.1)
 end
 
-function hideKeymap()
+function M.hideKeymap()
 	 modalCanvas:hide(0.1)
 end
 
-showReimod = function()
+function M.showReimod()
 	local frame = hs.screen.mainScreen():frame()
 	local currentScreen = hs.screen.mainScreen():name()
 	-- if (currentScreen == 'LG UltraFine') then
@@ -50,22 +55,22 @@ showReimod = function()
 	modalCanvas:show(0.1)
 end
 
-function hideReimod()
+function M.hideReimod()
 	 modalCanvas:hide(0.1)
 end
 
-mapShown = 0
-
-function toggleKeymap()
-	 if mapShown == 0 then
-		 showKeymap()
-		 mapShown = 1
-	 elseif mapShown == 1 then
-		 hideKeymap()
-		 showReimod()
-		 mapShown = 2
-	 else
-		 hideReimod()
-		 mapShown = 0
-	 end
+function M.toggleKeymap()
+         if mapShown == 0 then
+                 M.showKeymap()
+                 mapShown = 1
+         elseif mapShown == 1 then
+                 M.hideKeymap()
+                 M.showReimod()
+                 mapShown = 2
+         else
+                 M.hideReimod()
+                 mapShown = 0
+         end
 end
+
+return M

--- a/hammerspoon/yabai.lua
+++ b/hammerspoon/yabai.lua
@@ -3,10 +3,11 @@
 -- For cycling things you have to make your own script
 -- In short: Amethyst is far user friendlier.
 
+local M = {}
 
-function yabai(args, completion)
-	local yabai_output = ""
-	local yabai_error = ""
+function M.yabai(args, completion)
+        local yabai_output = ""
+        local yabai_error = ""
 	-- Runs in background very fast
 	local yabai_task = hs.task.new("/opt/homebrew/bin/yabai",nil, function(task, stdout, stderr)
 		--print("stdout:"..stdout, "stderr:"..stderr)
@@ -17,8 +18,10 @@ function yabai(args, completion)
 	if type(completion) == "function" then
 		yabai_task:setCallback(function() completion(yabai_output, yabai_error) end)
 	end
-	yabai_task:start()
+        yabai_task:start()
 end
+
+return M
 
 -- function yabai_cycle_display()
 --     -- local yabai_task = hs.task.new("/opt/homebrew/bin/yabaiyabai -m space --focus next || /opt/homebrew/bin/yabaiyabai -m space --focus first")


### PR DESCRIPTION
## Summary
- remove global functions from Hammerspoon scripts
- access keymap toggle via returned module

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make test` *(fails: No rule to make target 'test')*
- `make lint` *(fails: No rule to make target 'lint')*

------
https://chatgpt.com/codex/tasks/task_e_6841d76dd4248321b45b4b1fb643f8b0